### PR TITLE
simple spamy fix for float serialisation

### DIFF
--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -123,7 +123,7 @@ int add_value(char** dest, size_t* dest_size, int* current_offset, uint16_t node
             chars = write_string(*dest, *dest_size, "%d", val.ui32);
             break;
         case KOW_FLOAT:
-            chars = write_string(*dest, *dest_size, "%f", val.f);
+            chars = write_string(*dest, *dest_size, "%.17g", val.f);
             break;
         default:
             return -1;
@@ -507,7 +507,7 @@ static int val_to_str(struct kowhai_node_t *node, void *data, char *dst, int dst
                 r = snprintf(dst, dst_len, "%"PRIu32, val.ui32);
                 break;
             case KOW_FLOAT:
-                r = snprintf(dst, dst_len, "%f", val.f);
+                r = snprintf(dst, dst_len, "%.17g", val.f);
                 break;
             default:
                 return -1;

--- a/tools/test.c
+++ b/tools/test.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <assert.h>
 #include <time.h>
+#include <float.h>
+#include <math.h>
 
 #define COUNT_OF(x) ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
 
@@ -525,6 +527,9 @@ void serialization_tests()
     assert(memcmp(data, &settings, sizeof(settings)) == 0);
 
     // kowhai serialize (nodes)
+	settings.flux_capacitor[0].coefficient[1] = FLT_MIN; // test really small values can be deserialised without loosing precision
+	settings.flux_capacitor[0].coefficient[2] = 1.0f + FLT_EPSILON;
+	settings.flux_capacitor[0].coefficient[3] = 0.33f;
     buf_size = 10; // test dst buffer too small
     assert(kowhai_serialize_nodes(js, &buf_size, &settings_tree, path, COUNT_OF(path), NULL, get_symbol_name) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
     buf_size = BUF_SIZE; // test path too small
@@ -549,6 +554,10 @@ void serialization_tests()
     memset(&settings, 0, sizeof(settings));
     assert(kowhai_deserialize_nodes(js, buf_size, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_OK);
     assert(settings.flux_capacitor[0].frequency == settings2.flux_capacitor[0].frequency);
+	assert(settings.flux_capacitor[0].coefficient[1] == FLT_MIN); // test really small values can be de-serialised without loosing precision
+	assert(settings.flux_capacitor[0].coefficient[2] != 1.0f);
+	assert(settings.flux_capacitor[0].coefficient[2] == 1.0f + FLT_EPSILON);
+	assert(settings.flux_capacitor[0].coefficient[3] * 3.0f == 3.0f * 0.33f);
     assert(settings.flux_capacitor[FLUX_CAP_COUNT - 1].coefficient[COEFF_COUNT - 1] == settings2.flux_capacitor[FLUX_CAP_COUNT - 1].coefficient[COEFF_COUNT - 1]);
     assert(settings.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].beep == settings2.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].beep);
     assert(memcmp(settings.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].owner, settings2.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].owner, OWNER_MAX_LEN) == 0);


### PR DESCRIPTION
this is my first attempt to resolve this issue (I should try to making
something a little nicer and less spamy) ... basically it uses %g not %f
so we can go to scientific notation, but also sets the precision to 17
significant figures (spamy part) which according to some randoms here:

 http://stackoverflow.com/questions/4738768/printing-double-without-losing-precision

will ensure precision ... it seems to work and I have tried to add some
unit tests to catch edge issues, but I cannot find a float (or floating
point calculation) that is tripped up when I change the precision down
to 16, but it does fail for %f and precision <= 6

Ideally I would implement the solution of trying higher and higher
precisions for the number until it de-serialises back to the number we
put in, but thats another patch :)
