### PR TITLE
fix bug de serialising partial paths

### DIFF
--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -1233,7 +1233,6 @@ static int process_nodes_token(jsmn_parser *parser, int src_size, struct kowhai_
                 
                 t++;
                 tok++;
-                path[path_syms - 1].parts.array_index = i;
 
                 switch (type)
                 {
@@ -1265,6 +1264,7 @@ static int process_nodes_token(jsmn_parser *parser, int src_size, struct kowhai_
                 }
                 if (res != KOW_STATUS_OK)
                     return -2;
+                path[path_syms - 1].parts.array_index++;
             }
         }
 


### PR DESCRIPTION
this allows us to spec partial paths in our settings_XXXX.json files so we can load parts of the settings like the 1310nm power meter offset without overwritting the 1550nm one for example
